### PR TITLE
Fix: Update styles and confirm placeholder for superpowers

### DIFF
--- a/assets/css/templatemo-style.css
+++ b/assets/css/templatemo-style.css
@@ -509,7 +509,7 @@ figure.snip1321 span {
     font-size: 14px;
     font-style: italic;
     display: block;
-    color: #232323;
+    color: #fff;
 }
 figure.snip1321 i {
   position: relative!important;
@@ -524,7 +524,7 @@ figure.snip1321 i {
   color: #fff;
 }
 figure.snip1321:after {
-  background-color: #ffffff;
+  background-color: transparent;
   position: absolute;
   content: "";
   display: block;
@@ -728,16 +728,14 @@ section.contact-me {
     .isotope-item {
         width: 94%;
         margin: 3%;
+        border-bottom: none;
+        text-align: center;
     }
     .left-image-post img {
         margin-bottom: 30px;
     }
     .right-image-post img {
         margin-top: 30px;
-    }
-    .isotope-item {
-        border-bottom: none;
-        text-align: center;
     }
     .isotope-toolbar {
         margin-bottom: 20px;

--- a/index.html
+++ b/index.html
@@ -271,6 +271,42 @@
                 </figure>
               </div>
 
+              <div class="isotope-item">
+                <figure class="snip1321">
+                  <img src="assets/images/web.png" alt="PocketBase" />
+                  <figcaption>
+                    <span>PocketBase</span>
+                  </figcaption>
+                </figure>
+              </div>
+
+              <div class="isotope-item">
+                <figure class="snip1321">
+                  <img src="assets/images/web.png" alt="GoLang" />
+                  <figcaption>
+                    <span>GoLang</span>
+                  </figcaption>
+                </figure>
+              </div>
+
+              <div class="isotope-item">
+                <figure class="snip1321">
+                  <img src="assets/images/web.png" alt="Fly.io" />
+                  <figcaption>
+                    <span>Fly.io</span>
+                  </figcaption>
+                </figure>
+              </div>
+
+              <div class="isotope-item">
+                <figure class="snip1321">
+                  <img src="assets/images/web.png" alt="AWS" />
+                  <figcaption>
+                    <span>AWS</span>
+                  </figcaption>
+                </figure>
+              </div>
+
             </div>
           </div>
         </div>


### PR DESCRIPTION
- I removed the white hover highlight effect from the superpower cards by changing the background color of the hover pseudo-element to transparent in `assets/css/templatemo-style.css`.
- I changed the text color of the superpower card captions to white (`#fff`) for better visibility on hover, by modifying `figure.snip1321 span` in `assets/css/templatemo-style.css`.
- I added "PocketBase", "GoLang", "Fly.io", and "AWS" to the "My Superpowers" section in `index.html`.
- I confirmed with you that the existing `assets/images/web.png` is acceptable as a placeholder for the new superpower icons.
- I performed minor CSS cleanup by consolidating duplicate `.isotope-item` selectors within a media query in `assets/css/templatemo-style.css`.